### PR TITLE
APM-531 Set prod api products to internal only visibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "apigee_product" "product" {
   quota_time_unit = "minute"
 
   attributes = {
-    access = "public",
+    access = length(regexall("prod", var.apigee_environment)) > 0 ? "internal" : "public",
     ratelimit = "5ps"
   }
 


### PR DESCRIPTION
This PR is work towards the first two acceptance criteria of https://jira.digital.nhs.uk/browse/APM-531.

It ensures that production api products are only accessible internally.