### PR TITLE
Amb 52 monitoring and alerting with statuscake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
+.idea
 
 # .tfstate files
 *.tfstate

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -1,0 +1,12 @@
+provider "statuscake" {
+  username = var.status_cake_username
+  apikey = var.status_cake_api_key
+}
+
+resource "statuscake_test" "google" {
+  website_name = "google.com"
+  website_url  = "www.google.com"
+  test_type    = "HTTP"
+  check_rate   = 300
+  contact_group   = var.status_cake_contact_group
+}

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -5,7 +5,7 @@ provider "statuscake" {
 }
 
 locals {
-  service_name = "${var.name}-${var.apigee_environment}-${var.namespace}"
+  service_name = "${var.name}-${var.apigee_environment}"
   website_name = "https://${var.apigee_environment}.api.service.nhs.uk"
   ping_url = "${local.website_name}/${var.path}/_ping"
   status_url = "${local.website_name}/${var.path}/_status"

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -1,6 +1,7 @@
 provider "statuscake" {
   username = var.status_cake_username
   apikey = var.status_cake_api_key
+  version = "1.0.0"
 }
 
 locals {

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -3,10 +3,24 @@ provider "statuscake" {
   apikey = var.status_cake_api_key
 }
 
-resource "statuscake_test" "google" {
-  website_name = "google.com"
-  website_url  = "www.google.com"
+locals {
+  website_name = "${var.apigee_environment}.api.service.nhs.uk"
+  ping_url = "${local.website_name}/${var.path}/_ping"
+  status_url = "${local.website_name}/${var.path}/_status"
+}
+
+resource "statuscake_test" "ping" {
+  website_name = local.website_name
+  website_url  = local.ping_url
   test_type    = "HTTP"
   check_rate   = 300
-  contact_group   = var.status_cake_contact_group
+  contact_group   = [var.status_cake_contact_group]
+}
+
+resource "statuscake_test" "status" {
+  website_name = local.website_name
+  website_url  = local.status_url
+  test_type    = "HTTP"
+  check_rate   = 300
+  contact_group   = [var.status_cake_contact_group]
 }

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -17,6 +17,8 @@ resource "statuscake_test" "ping" {
   test_type    = "HTTP"
   check_rate   = 300
   contact_group   = [var.status_cake_contact_group]
+  # Only deploy if namespace is empty. i.e don't create alerts for namespaced deployments
+  count = length(var.namespace) > 0 ? 0 : 1
 }
 
 resource "statuscake_test" "status" {
@@ -25,4 +27,6 @@ resource "statuscake_test" "status" {
   test_type    = "HTTP"
   check_rate   = 300
   contact_group   = [var.status_cake_contact_group]
+  # Only deploy if namespace is empty. i.e don't create alerts for namespaced deployments
+  count = length(var.namespace) > 0 ? 0 : 1
 }

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -4,7 +4,7 @@ provider "statuscake" {
 }
 
 locals {
-  website_name = "${var.apigee_environment}.api.service.nhs.uk"
+  website_name = "https://${var.apigee_environment}.api.service.nhs.uk"
   ping_url = "${local.website_name}/${var.path}/_ping"
   status_url = "${local.website_name}/${var.path}/_status"
 }

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -4,13 +4,14 @@ provider "statuscake" {
 }
 
 locals {
+  service_name = "${var.apigee_environment} ${var.namespace}"
   website_name = "https://${var.apigee_environment}.api.service.nhs.uk"
   ping_url = "${local.website_name}/${var.path}/_ping"
   status_url = "${local.website_name}/${var.path}/_status"
 }
 
 resource "statuscake_test" "ping" {
-  website_name = local.website_name
+  website_name = local.service_name
   website_url  = local.ping_url
   test_type    = "HTTP"
   check_rate   = 300
@@ -18,7 +19,7 @@ resource "statuscake_test" "ping" {
 }
 
 resource "statuscake_test" "status" {
-  website_name = local.website_name
+  website_name = local.service_name
   website_url  = local.status_url
   test_type    = "HTTP"
   check_rate   = 300

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -27,6 +27,7 @@ resource "statuscake_test" "status" {
   test_type    = "HTTP"
   check_rate   = 300
   contact_group   = [var.status_cake_contact_group]
+  custom_header = jsonencode({"apikey": var.status_cake_status_apikey})
   # Only deploy if namespace is empty. i.e don't create alerts for namespaced deployments
   count = length(var.namespace) > 0 ? 0 : 1
 }

--- a/statuscake.tf
+++ b/statuscake.tf
@@ -4,14 +4,14 @@ provider "statuscake" {
 }
 
 locals {
-  service_name = "${var.apigee_environment} ${var.namespace}"
+  service_name = "${var.name}-${var.apigee_environment}-${var.namespace}"
   website_name = "https://${var.apigee_environment}.api.service.nhs.uk"
   ping_url = "${local.website_name}/${var.path}/_ping"
   status_url = "${local.website_name}/${var.path}/_status"
 }
 
 resource "statuscake_test" "ping" {
-  website_name = local.service_name
+  website_name = "${local.service_name}-ping"
   website_url  = local.ping_url
   test_type    = "HTTP"
   check_rate   = 300
@@ -19,7 +19,7 @@ resource "statuscake_test" "ping" {
 }
 
 resource "statuscake_test" "status" {
-  website_name = local.service_name
+  website_name =  "${local.service_name}-status"
   website_url  = local.status_url
   test_type    = "HTTP"
   check_rate   = 300

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,18 @@ variable "env_names" {
     prod                = "Production"
   }
 }
+
+variable "status_cake_username" {
+  type = string
+  description = "Statuscake username for monitoring and alerting"
+}
+
+variable "status_cake_api_key" {
+  type = string
+  description = "Statuscake apikey for monitoring and alerting"
+}
+
+variable "status_cake_contact_group" {
+  type = string
+  description = "Statuscake Contact Group for monitoring and alerting"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,8 @@ variable "status_cake_contact_group" {
   type = string
   description = "Statuscake Contact Group for monitoring and alerting"
 }
+
+variable "status_cake_status_apikey" {
+  type = string
+  description = "Apikey for the _status endpoint"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,7 @@ variable "proxy_type" {
 
 variable "namespace" {
   type = string
+  default = ""
   description = "String appended to the end of proxy and product names to allow namespaced deploys, for PRs and such"
 }
 


### PR DESCRIPTION
Add statuscake deployment for two endpoints, `_status` and `_ping`.
`_status` should return backend status and `_ping` returns proxy.