### PR TITLE
APM-1075 Do not use latest and explicitly set the correct proxy version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "apigee_api_proxy" "proxy" {
 resource "apigee_api_proxy_deployment" "proxy_deployment" {
   proxy_name = apigee_api_proxy.proxy.name
   env = var.apigee_environment
-  revision = "latest"
+  revision = apigee_api_proxy.proxy.revision
 
   # This tells the deploy to give existing connections a 60 grace period before abandoning them,
   # and otherwise deploys seamlessly.


### PR DESCRIPTION
This is to fix an issue where the latest revisions of proxies are not deployed.